### PR TITLE
Update demo to use domain .local instead .localhost

### DIFF
--- a/charts/rstuf-demo/Chart.yaml
+++ b/charts/rstuf-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rstuf-demo
 description: RSTUF Demo deploying RSTUF services and infrastructure services. This deployment is not recommended for production.
-version: 0.3.2
+version: 0.3.3
 maintainers:
   - name: kairoaraujo
 

--- a/charts/rstuf-demo/values.yaml
+++ b/charts/rstuf-demo/values.yaml
@@ -8,7 +8,7 @@ rstuf-api:
   ingress:
     enabled: true
     hosts:
-      - host: rstuf.localhost
+      - host: rstuf.local
         paths:
           - path: /
             pathType: ImplementationSpecific
@@ -69,7 +69,7 @@ localstack:
     metadata:
       name: ingress-resource-backend
     hosts:
-      - host: localstack.localhost
+      - host: localstack.local
         paths:
           - path: /
             pathType: ImplementationSpecific


### PR DESCRIPTION
Uses the .local instead .localhost.
Some users can face issues with the localhost domain.