### PR TITLE
rstuf-demo: enable localstack persistent

### DIFF
--- a/charts/rstuf-demo/Chart.yaml
+++ b/charts/rstuf-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rstuf-demo
 description: RSTUF Demo deploying RSTUF services and infrastructure services. This deployment is not recommended for production.
-version: 0.3.5
+version: 0.3.6
 maintainers:
   - name: kairoaraujo
 

--- a/charts/rstuf-demo/values.yaml
+++ b/charts/rstuf-demo/values.yaml
@@ -64,6 +64,8 @@ postgresql:
 localstack:
   enabled: true
   debug: true
+  persistence:
+    enabled: true
   ingress:
     enabled: true
     metadata:


### PR DESCRIPTION
enable localstack persistence by default avoiding losing KMS key or S3 bucket storage in case of delete/redeploy