### PR TITLE
Update worker charts to support broker ssl

### DIFF
--- a/charts/rstuf-worker/templates/deployment.yaml
+++ b/charts/rstuf-worker/templates/deployment.yaml
@@ -55,6 +55,11 @@ spec:
               mountPath: /run/secrets/gcp-credentials
               readOnly: true
             {{- end }}
+            {{- if .Values.brokerSsl.enabled }}
+            - name: broker-ssl-certs-volume
+              mountPath: {{ .Values.brokerSsl.mountPath }}
+              readOnly: true
+            {{- end}}
             {{- if .Values.onlineKeyFile }}
             {{- range .Values.onlineKeyFile }}
             - name: {{ .keyid | printf "%.7s" }}-keyfile-volume
@@ -123,6 +128,16 @@ spec:
             - name: RSTUF_GOOGLE_APPLICATION_CREDENTIALS
               value: /run/secrets/gcp-credentials/ac.json
             {{- end }}
+            {{- if .Values.brokerSsl.enabled }}
+            - name: RSTUF_BROKER_SSL_ENABLE
+              value: "true"
+            - name: RSTUF_BROKER_SSL_KEYFILE
+              value: {{ cat .Values.brokerSsl.mountPath "/" .Values.brokerSsl.keyFileName | quote }}
+            - name: RSTUF_BROKER_SSL_CERTFILE
+              value: {{ cat .Values.brokerSsl.mountPath "/" .Values.brokerSsl.certFileName | quote }}
+            - name: RSTUF_BROKER_SSL_CA_CERTS
+              value: {{ cat .Values.brokerSsl.mountPath "/" .Values.brokerSsl.caFileName | quote }}
+            {{- end }}
       volumes:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
@@ -138,6 +153,11 @@ spec:
           secret:
             secretName: {{ .keyid }}-keyfile-secret
         {{- end }}
+        {{- end }}
+        {{-if .Values.brokerSsl.enabled }}
+        - name: broker-ssl-certs-volume
+          secret:
+            secretName: broker-ssl-certs
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/rstuf-worker/templates/secrets.yaml
+++ b/charts/rstuf-worker/templates/secrets.yaml
@@ -24,3 +24,16 @@ data:
 ---
 {{- end }}
 {{- end }}
+# Create SSL secret if enabled
+{{- if .Values.brokerSsl.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: broker-ssl-certs
+type: Opaque
+data:
+  {{ .Values.brokerSsl.keyFileName }}: {{ .Values.brokerSsl.keyData | b64enc | quote }}
+  {{ .Values.brokerSsl.certFileName }}: {{ .Values.brokerSsl.certData | b64enc | quote}}
+  {{ .Values.brokerSsl.caFileName }}: {{ .Values.brokerSsl.caData | b64enc | quote}}
+{{- end}}

--- a/charts/rstuf-worker/values.yaml
+++ b/charts/rstuf-worker/values.yaml
@@ -60,6 +60,16 @@ backend:
   # redisDbSettings default is 1
   redisDbSettings: ""
 
+brokerSsl:
+  enabled: false
+  mountPath: "/run/secrets/broker_ssl"
+  keyData: ""
+  certData: ""
+  caData: ""
+  keyFileName: "tls.key"
+  certFileName: "tls.crt"
+  caFileName: "ca.crt"
+
 # using online key as file in seccrets
 # onlineKeyDir: "/run/secrets"
 # onlineKeyFile:


### PR DESCRIPTION
Updated the `deployment.yaml`, `values.yaml` and `secrets.yaml` to support SSL config parameters as container secrets for broker connections under `rstuf-worker`

Related Issue: https://github.com/repository-service-tuf/repository-service-tuf-worker/issues/709

CC: @kairoaraujo 

