### PR TITLE
fix: correct lockTimeOut value check in worker deployment template

### DIFF
--- a/charts/rstuf-worker/templates/deployment.yaml
+++ b/charts/rstuf-worker/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
             - name: RSTUF_REDIS_SERVER_DB_REPO_SETTINGS
               value: {{ .Values.backend.redisDbSettings | quote }}
             {{- end }}
-            {{- if .Values.backend.lockTimeOut }}
+            {{- if ne (.Values.backend.lockTimeOut | toString) "" }}
             - name: RSTUF_LOCK_TIMEOUT
               value: {{ .Values.backend.lockTimeOut | quote }}
             {{- end }}


### PR DESCRIPTION
## Summary

* Replace `{{- if .Values.backend.lockTimeOut }}` with `{{- if ne (.Values.backend.lockTimeOut | toString) "" }}` in `charts/rstuf-worker/templates/deployment.yaml`
* The original check treats numeric `0` as falsy, silently dropping `RSTUF_LOCK_TIMEOUT` from the deployment env vars
* Converting to string before comparison handles both string and integer values correctly

## Test 

* `helm template` with `lockTimeOut=60` renders `RSTUF_LOCK_TIMEOUT: "60"`
* `helm template` with `lockTimeOut` unset does not render the env var
* `helm template` with `lockTimeOut=0` renders `RSTUF_LOCK_TIMEOUT: "0"`
* `helm lint charts/rstuf-worker` passes with no failures

Fixes #2