### PR TITLE
Security hardening: run services as non-root user

### DIFF
--- a/charts/rstuf-api/Chart.yaml
+++ b/charts/rstuf-api/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rstuf-api/templates/deployment.yaml
+++ b/charts/rstuf-api/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.service.targetPort | default 8080 }}
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/charts/rstuf-api/values.yaml
+++ b/charts/rstuf-api/values.yaml
@@ -31,17 +31,19 @@ podLabels: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
 
 service:
   type: NodePort
   port: 80
+  targetPort: 8080
   ssl_cert: ""
   ssl_key: ""
   # Disable RSTUF API endpoints

--- a/charts/rstuf-worker/Chart.yaml
+++ b/charts/rstuf-worker/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rstuf-worker/values.yaml
+++ b/charts/rstuf-worker/values.yaml
@@ -85,13 +85,14 @@ podLabels: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This change updates the containers to run as a non-root user instead of root.

Summary of changes:
- Created a dedicated user named tuf (UID 1000) inside the containers
- Updated file and directory permissions so the tuf user can access required paths
- Changed internal service ports from 80 to 8080 so root privileges are not required
- Updated container and deployment configuration to enforce non-root execution
- Adjusted supervisor configuration for worker to use writable directories
- Updated Helm charts to set securityContext with runAsNonRoot

Why this change:
Running containers as root is not recommended for security reasons. Running as a non-root user follows container security best practices and reduces risk in production environments.

Testing:
The configuration was verified to ensure the API and Worker can start under non-root permissions and the container setup remains consistent with docker-compose and Helm deployment.

This change is coordinated with the umbrella repository PR:
https://github.com/repository-service-tuf/repository-service-tuf/pull/934