### PR TITLE
security: run services as non-root user (RSTUF-CR-25-111)

### DIFF
--- a/charts/rstuf-api/templates/deployment.yaml
+++ b/charts/rstuf-api/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.service.port }}
+              containerPort: {{ .Values.service.targetPort | default 8080 }}
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/charts/rstuf-api/values.yaml
+++ b/charts/rstuf-api/values.yaml
@@ -31,17 +31,17 @@ podLabels: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  allowPrivilegeEscalation: false
 
 service:
   type: NodePort
   port: 80
+  targetPort: 8080
   ssl_cert: ""
   ssl_key: ""
   # Disable RSTUF API endpoints

--- a/charts/rstuf-worker/values.yaml
+++ b/charts/rstuf-worker/values.yaml
@@ -85,13 +85,12 @@ podLabels: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  allowPrivilegeEscalation: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This change updates the Helm charts to enforce non-root execution for API and Worker containers.

Changes:

* Added securityContext with runAsNonRoot, runAsUser, runAsGroup, and fsGroup
* Updated container targetPort to 8080 for the API service
* Ensured Kubernetes deployments run containers as UID 1000

This aligns the Kubernetes deployment with the security hardening changes applied to the containers.

Fixes #859
Related to #852
RSTUF-CR-25-111
