### PR TITLE
feat: add rstuf-visualizer chart and integrate with rstuf-demo

### DIFF
--- a/charts/rstuf-demo/Chart.yaml
+++ b/charts/rstuf-demo/Chart.yaml
@@ -36,3 +36,7 @@ dependencies:
     version: 0.6.25
     repository: "https://localstack.github.io/helm-charts"
     condition: localstack.enabled
+  - name: rstuf-visualizer
+    version: 0.1.0
+    repository: "file://../rstuf-visualizer"
+    condition: rstuf-visualizer.enabled

--- a/charts/rstuf-demo/values.yaml
+++ b/charts/rstuf-demo/values.yaml
@@ -93,3 +93,13 @@ rabbitmq:
 
 mysql:
   enabled: false
+
+rstuf-visualizer:
+  enabled: true
+  env:
+    NEXT_PUBLIC_RSTUF_API: "http://rstuf-api:80/api/v1/metadata/"
+  # Optional: ensure it waits for the API to be ready
+  initContainers:
+    - name: wait-for-api
+      image: busybox:1.37
+      command: ['sh', '-c', 'until nc -z rstuf-api.rstuf.svc.cluster.local 80; do echo "waiting for RSTUF API..."; sleep 2; done;']

--- a/charts/rstuf-visualizer/Chart.yaml
+++ b/charts/rstuf-visualizer/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: rstuf-visualizer
+description: A TUF Metadata Visualizer Helm chart for RSTUF
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+maintainers:
+  - name: kairoaraujo

--- a/charts/rstuf-visualizer/templates/_helpers.tpl
+++ b/charts/rstuf-visualizer/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rstuf-visualizer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rstuf-visualizer.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rstuf-visualizer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rstuf-visualizer.labels" -}}
+helm.sh/chart: {{ include "rstuf-visualizer.chart" . }}
+{{ include "rstuf-visualizer.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rstuf-visualizer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rstuf-visualizer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/rstuf-visualizer/templates/deployment.yaml
+++ b/charts/rstuf-visualizer/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rstuf-visualizer.fullname" . }}
+  labels:
+    {{- include "rstuf-visualizer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "rstuf-visualizer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "rstuf-visualizer.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+          env:
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/rstuf-visualizer/templates/service.yaml
+++ b/charts/rstuf-visualizer/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rstuf-visualizer.fullname" . }}
+  labels:
+    {{- include "rstuf-visualizer.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "rstuf-visualizer.selectorLabels" . | nindent 4 }}

--- a/charts/rstuf-visualizer/values.yaml
+++ b/charts/rstuf-visualizer/values.yaml
@@ -1,0 +1,30 @@
+# Default values for rstuf-visualizer.
+replicaCount: 1
+
+image:
+  repository: tuf-visualizer
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 3000
+
+env:
+  NEXT_PUBLIC_RSTUF_API: "http://rstuf-api:80/api/v1/metadata/"
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
This PR introduces a Helm chart for the TUF Metadata Visualizer and integrates it into the rstuf-demo deployment.

Changes:

* Added a new chart `rstuf-visualizer` with deployment and service templates.
* Configured environment variable injection for RSTUF API connectivity.
* Integrated the visualizer as a dependency in the `rstuf-demo` chart.
* Added optional initContainer to wait for API readiness.

Result:
The RSTUF stack can now be deployed with the visualizer included using Helm.

Related work:

* Docker integration: https://github.com/repository-service-tuf/repository-service-tuf/pull/960
* Visualizer updates: https://github.com/DeshDeepakKant/TUF-Metadata-Visualizer/pull/38

This PR complements the visualizer integration by enabling deployment via Helm.
