### PR TITLE
Replace Bitnami images in rstuf-demo with cloudpirates Postgres and official Valkey

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,9 @@ jobs:
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
         with:
+          version: "3.14.0"
           yamale_version: "6.1.0"
 
       - name: Run chart-testing (list-changed)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,13 +59,12 @@ jobs:
         run: |
           changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           if [[ "$changed" == *"charts/rstuf-demo"* ]]; then
+            kubectl create namespace rstuf --dry-run=client -o yaml | kubectl apply -f -
             ct install --charts charts/rstuf-demo \
             --namespace rstuf \
-            --release-name rstuf-demo \
             --chart-repos=cloudpirates=https://cloudpirates-io.github.io/helm-charts \
             --chart-repos=valkey=https://valkey.io/valkey-helm \
             --chart-repos=rstuf=https://repository-service-tuf.github.io/helm-charts \
             --chart-repos=localstack=https://localstack.github.io/helm-charts \
-            --helm-extra-args="--create-namespace" \
-            --helm-extra-set-args="--set rstuf-worker.initContainers=null,rstuf-api.initContainers=null"
+            --helm-extra-set-args="--set postgres.fullnameOverride=rstuf-demo-postgres,valkey.fullnameOverride=rstuf-demo-valkey,localstack.fullnameOverride=rstuf-demo-localstack,rstuf-worker.initContainers=null,rstuf-api.initContainers=null"
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,20 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --target-branch ${{ github.event.repository.default_branch }} \
-          --chart-repos=cloudpirates=https://cloudpirates-io.github.io/helm-charts \
-          --chart-repos=valkey=https://valkey.io/valkey-helm \
-          --chart-repos=rstuf=https://repository-service-tuf.github.io/helm-charts \
-          --chart-repos=localstack=https://localstack.github.io/helm-charts \
-          --helm-extra-args="--namespace rstuf --create-namespace" \
-          --helm-extra-set-args="--set postgres.fullnameOverride=rstuf-demo-postgres,valkey.fullnameOverride=rstuf-demo-valkey,localstack.fullnameOverride=rstuf-demo-localstack,rstuf-worker.initContainers=null,rstuf-api.initContainers=null" \
+          --excluded-charts rstuf-demo
+
+      - name: Run chart-testing (install rstuf-demo)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ "$changed" == *"charts/rstuf-demo"* ]]; then
+            ct install --charts charts/rstuf-demo \
+            --namespace rstuf \
+            --release-name rstuf-demo \
+            --chart-repos=cloudpirates=https://cloudpirates-io.github.io/helm-charts \
+            --chart-repos=valkey=https://valkey.io/valkey-helm \
+            --chart-repos=rstuf=https://repository-service-tuf.github.io/helm-charts \
+            --chart-repos=localstack=https://localstack.github.io/helm-charts \
+            --helm-extra-args="--create-namespace" \
+            --helm-extra-set-args="--set rstuf-worker.initContainers=null,rstuf-api.initContainers=null"
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b
+        with:
+          yamale_version: "6.1.0"
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,12 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-repos=bitnami=https://charts.bitnami.com/bitnami
+        run: |
+          ct lint --target-branch ${{ github.event.repository.default_branch }} \
+          --chart-repos=cloudpirates=https://cloudpirates-io.github.io/helm-charts \
+          --chart-repos=valkey=https://valkey.io/valkey-helm \
+          --chart-repos=rstuf=https://repository-service-tuf.github.io/helm-charts \
+          --chart-repos=localstack=https://localstack.github.io/helm-charts
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
@@ -44,7 +49,8 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --target-branch ${{ github.event.repository.default_branch }} \
-          --chart-repos=bitnami=https://charts.bitnami.com/bitnami \
+          --chart-repos=cloudpirates=https://cloudpirates-io.github.io/helm-charts \
+          --chart-repos=valkey=https://valkey.io/valkey-helm \
           --chart-repos=rstuf=https://repository-service-tuf.github.io/helm-charts \
           --chart-repos=localstack=https://localstack.github.io/helm-charts \
           --helm-extra-set-args="--set rstuf-worker.initContainers=null,rstuf-api.initContainers=null" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,4 +55,5 @@ jobs:
           --chart-repos=valkey=https://valkey.io/valkey-helm \
           --chart-repos=rstuf=https://repository-service-tuf.github.io/helm-charts \
           --chart-repos=localstack=https://localstack.github.io/helm-charts \
-          --helm-extra-set-args="--set rstuf-worker.initContainers=null,rstuf-api.initContainers=null" \
+          --helm-extra-args="--namespace rstuf --create-namespace" \
+          --helm-extra-set-args="--set postgres.fullnameOverride=rstuf-demo-postgres,valkey.fullnameOverride=rstuf-demo-valkey,localstack.fullnameOverride=rstuf-demo-localstack,rstuf-worker.initContainers=null,rstuf-api.initContainers=null" \

--- a/charts/rstuf-demo/Chart.yaml
+++ b/charts/rstuf-demo/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: rstuf-demo
 description: RSTUF Demo deploying RSTUF services and infrastructure services. This deployment is not recommended for production.
-version: 0.3.14
+version: 0.3.15
 maintainers:
   - name: kairoaraujo
 
@@ -12,26 +12,14 @@ dependencies:
   - name: rstuf-worker
     version: 0.4.3
     repository: "https://repository-service-tuf.github.io/helm-charts"
-  - name: postgresql
-    version: 16.7.27
-    repository: "https://charts.bitnami.com/bitnami"
+  - name: postgres
+    version: 0.19.6
+    repository: "https://cloudpirates-io.github.io/helm-charts"
     condition: postgres.enabled
-  - name: redis
-    version: 22.0.7
-    repository: "https://charts.bitnami.com/bitnami"
-    condition: redis.enabled
   - name: valkey
-    version: 3.0.31
-    repository: "https://charts.bitnami.com/bitnami"
+    version: 0.10.0
+    repository: "https://valkey.io/valkey-helm"
     condition: valkey.enabled
-  - name: rabbitmq
-    version: 16.0.14
-    repository: "https://charts.bitnami.com/bitnami"
-    condition: rabbitmq.enabled
-  - name: mysql
-    version: 14.0.3
-    repository: https://charts.bitnami.com/bitnami
-    condition: mysql.enabled
   - name: localstack
     version: 0.6.25
     repository: "https://localstack.github.io/helm-charts"

--- a/charts/rstuf-demo/values.yaml
+++ b/charts/rstuf-demo/values.yaml
@@ -81,4 +81,3 @@ localstack:
     awslocal kms create-key --key-spec RSA_4096 --key-usage SIGN_VERIFY
     awslocal kms create-alias --alias-name alias/aws-test-key --target-key-id $(awslocal kms list-keys --query "Keys[0].KeyId" --output text)
     awslocal s3 mb s3://tuf-metadata
-

--- a/charts/rstuf-demo/values.yaml
+++ b/charts/rstuf-demo/values.yaml
@@ -2,10 +2,10 @@ rstuf-api:
   initContainers:
     - name: wait-for-valkey
       image: busybox:1.37
-      command: ['sh', '-c', 'until nc -z rstuf-valkey-primary.rstuf.svc.cluster.local 6379 ; do echo "waiting for Valkey..."; sleep 2; done;']
+      command: ['sh', '-c', 'until nc -z rstuf-demo-valkey.rstuf.svc.cluster.local 6379 ; do echo "waiting for Valkey..."; sleep 2; done;']
   backend:
-    brokerServer: "redis://rstuf-valkey-primary.rstuf.svc.cluster.local"
-    redisServer: "redis://rstuf-valkey-primary.rstuf.svc.cluster.local"
+    brokerServer: redis://rstuf-demo-valkey.rstuf.svc.cluster.local
+    redisServer: redis://rstuf-demo-valkey.rstuf.svc.cluster.local
   ingress:
     enabled: true
     hosts:
@@ -19,14 +19,14 @@ rstuf-worker:
   initContainers:
     - name: wait-for-valkey
       image: busybox:1.37
-      command: ['sh', '-c', 'until nc -z rstuf-valkey-primary.rstuf.svc.cluster.local 6379 ; do echo "waiting for Valkey..."; sleep 2; done;']
+      command: ['sh', '-c', 'until nc -z rstuf-demo-valkey.rstuf.svc.cluster.local 6379 ; do echo "waiting for Valkey..."; sleep 2; done;']
     - name: wait-for-postgres
       image: busybox:1.37
-      command: ['sh', '-c', 'until nc -z rstuf-postgresql.rstuf.svc.cluster.local 5432; do echo "waiting for Postgres..."; sleep 2; done;']
+      command: ['sh', '-c', 'until nc -z rstuf-demo-postgres.rstuf.svc.cluster.local 5432; do echo "waiting for Postgres..."; sleep 2; done;']
   backend:
-    dbServer: "postgresql://postgres:postgres@rstuf-postgresql.rstuf.svc.cluster.local/rstuf"
-    brokerServer: "redis://rstuf-valkey-primary.rstuf.svc.cluster.local"
-    redisServer: "redis://rstuf-valkey-primary.rstuf.svc.cluster.local"
+    dbServer: "postgresql://postgres:postgres@rstuf-demo-postgres.rstuf.svc.cluster.local/rstuf"
+    brokerServer: redis://rstuf-demo-valkey.rstuf.svc.cluster.local
+    redisServer: redis://rstuf-demo-valkey.rstuf.svc.cluster.local
   storage:
     type: "AWSS3"
     s3Bucket: "tuf-metadata"
@@ -34,40 +34,34 @@ rstuf-worker:
     accessKey: "s3-keyid"
     secretKey: "s3-access-key"
     region: "us-east-1"
-    endpoint: "http://rstuf-localstack.rstuf.svc.cluster.local:4566"
+    endpoint: "http://rstuf-demo-localstack.rstuf.svc.cluster.local:4566"
 
 valkey:
   enabled: true
-  architecture: standalone
   auth:
     enabled: false
-  persistence:
+  service:
+    port: 6379
+  dataStorage:
     enabled: true
-    size: 2Gi
-  master:
-    service:
-      port: 6379
+    requestedSize: 2Gi
 
-redis:
-  enabled: false
-
-postgresql:
+postgres:
   enabled: true
   auth:
     username: postgres
     password: postgres
     database: rstuf
-  primary:
-    persistence:
-      enabled: true
-      size: 8Gi  # Adjust size as necessary
-  replication:
-    enabled: false
+  persistence:
+    enabled: true
+    size: 8Gi
   service:
     port: 5432
 
 localstack:
   enabled: true
+  image:
+    tag: "4.4.0"
   debug: true
   persistence:
     enabled: true
@@ -88,8 +82,3 @@ localstack:
     awslocal kms create-alias --alias-name alias/aws-test-key --target-key-id $(awslocal kms list-keys --query "Keys[0].KeyId" --output text)
     awslocal s3 mb s3://tuf-metadata
 
-rabbitmq:
-  enabled: false
-
-mysql:
-  enabled: false


### PR DESCRIPTION
## Summary

Replaces Bitnami subchart dependencies in `rstuf-demo` with maintained alternatives to resolve image pull issues and reduce reliance on Bitnami charts.

- **PostgreSQL:** Bitnami `postgresql` → [cloudpirates `postgres`](https://cloudpirates-io.github.io/helm-charts) `0.19.6`
- **Valkey:** Bitnami `valkey` → [official Valkey Helm chart](https://valkey.io/valkey-helm) `0.10.0`
- **Removed** unused Bitnami dependencies: `redis`, `rabbitmq`, `mysql`
- **LocalStack:** pinned image to `4.4.0` to avoid auth token requirement introduced in LocalStack `2026.3.0+`
- **Service hostnames** updated for release name `rstuf-demo` (Valkey, Postgres, LocalStack)
- **CI:** updated chart-testing repos from Bitnami to cloudpirates and Valkey
- **Chart version:** bumped to `0.3.15`

## Motivation

Bitnami chart images were failing to pull in local/demo deployments (`ImagePullBackOff`). This migration uses official/community-maintained charts instead.

## Test plan

- [x] `helm dependency update .`
- [x] `helm lint .`
- [x] `helm upgrade --install rstuf-demo . -n rstuf --create-namespace`
- [x] All pods reach `Running`:
  - `rstuf-demo-valkey`
  - `rstuf-demo-postgres-0`
  - `rstuf-demo-rstuf-api`
  - `rstuf-demo-rstuf-worker`
  - `rstuf-demo-localstack`
- [x] `minikube tunnel` + ingress smoke test:
  - http://rstuf.local — RSTUF API loads
  - http://localstack.local/tuf-metadata — S3 bucket `tuf-metadata` exists