### PR TITLE
feat(rstuf-worker): add flexible configuration for secrets and deployment strategy

### DIFF
--- a/charts/rstuf-worker/Chart.yaml
+++ b/charts/rstuf-worker/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rstuf-worker/templates/deployment.yaml
+++ b/charts/rstuf-worker/templates/deployment.yaml
@@ -8,6 +8,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "rstuf-worker.selectorLabels" . | nindent 6 }}
@@ -59,7 +63,7 @@ spec:
             {{- range .Values.onlineKeyFile }}
             - name: {{ .keyid | printf "%.7s" }}-keyfile-volume
               mountPath: /run/secrets/{{ .keyid }}
-              subPath: {{ .keyid }}
+              subPath: {{ .secretKey | default .keyid }}
             {{- end }}
             {{- end }}
           env:
@@ -67,15 +71,46 @@ spec:
               value: {{ .Values.backend.brokerServer | quote }}
             - name: RSTUF_REDIS_SERVER
               value: {{ .Values.backend.redisServer | quote }}
+            {{- if .Values.backend.redisPort }}
+            - name: RSTUF_REDIS_SERVER_PORT
+              value: {{ .Values.backend.redisPort | quote }}
+            {{- end }}
+            {{- if .Values.backend.redisDbResult }}
+            - name: RSTUF_REDIS_SERVER_DB_RESULT
+              value: {{ .Values.backend.redisDbResult | quote }}
+            {{- end }}
+            {{- if .Values.backend.redisDbSettings }}
+            - name: RSTUF_REDIS_SERVER_DB_REPO_SETTINGS
+              value: {{ .Values.backend.redisDbSettings | quote }}
+            {{- end }}
+            {{- if .Values.backend.dbServer }}
             - name: RSTUF_DB_SERVER
               value: {{ .Values.backend.dbServer | quote }}
+            {{- else if .Values.backend.dbServerFrom }}
+            - name: RSTUF_DB_SERVER
+              {{- toYaml .Values.backend.dbServerFrom | nindent 14 }}
+            {{- end }}
+            {{- if .Values.backend.dbUser }}
+            - name: RSTUF_DB_USER
+              value: {{ .Values.backend.dbUser | quote }}
+            {{- else if .Values.backend.dbUserFrom }}
+            - name: RSTUF_DB_USER
+              {{- toYaml .Values.backend.dbUserFrom | nindent 14 }}
+            {{- end }}
+            {{- if .Values.backend.dbPassword }}
+            - name: RSTUF_DB_PASSWORD
+              value: {{ .Values.backend.dbPassword | quote }}
+            {{- else if .Values.backend.dbPasswordFrom }}
+            - name: RSTUF_DB_PASSWORD
+              {{- toYaml .Values.backend.dbPasswordFrom | nindent 14 }}
+            {{- end }}
             - name: RSTUF_STORAGE_BACKEND
               value: {{ required "storage.type must be 'AWSS3' or 'LocalStorage'." .Values.storage.type | quote }}
             {{- if eq .Values.storage.type "LocalStorage" }}
             - name: RSTUF_LOCAL_STORAGE_BACKEND_PATH
               value: {{ required "storage.backendPath is required when storage.type is 'LocalStorage'." .Values.storage.storagePath | quote }}
             {{- end }}
-            {{- if .Values.onlineKeyDir }}
+            {{- if and .Values.onlineKeyDir .Values.onlineKeyFile }}
             - name: RSTUF_ONLINE_KEY_DIR
               value: {{ .Values.onlineKeyDir | quote }}
             {{- end }}
@@ -86,10 +121,16 @@ spec:
             {{- if .Values.aws.accessKey }}
             - name: RSTUF_AWS_ACCESS_KEY_ID
               value: {{ .Values.aws.accessKey | quote }}
+            {{- else if .Values.aws.accessKeyFrom }}
+            - name: RSTUF_AWS_ACCESS_KEY_ID
+              {{- toYaml .Values.aws.accessKeyFrom | nindent 14 }}
             {{- end }}
-            {{- if .Values.aws.secretKey  }}
+            {{- if .Values.aws.secretKey }}
             - name: RSTUF_AWS_SECRET_ACCESS_KEY
               value: {{ .Values.aws.secretKey | quote }}
+            {{- else if .Values.aws.secretKeyFrom }}
+            - name: RSTUF_AWS_SECRET_ACCESS_KEY
+              {{- toYaml .Values.aws.secretKeyFrom | nindent 14 }}
             {{- end }}
             {{- if .Values.aws.region }}
             - name: RSTUF_AWS_DEFAULT_REGION
@@ -102,18 +143,6 @@ spec:
             {{- if .Values.aws.s3_object_acl }}
             - name: RSTUF_AWS_S3_OBJECT_ACL
               value: {{ .Values.aws.s3_object_acl | quote }}
-            {{- end }}
-            {{- if .Values.backend.redisPort }}
-            - name: RSTUF_REDIS_SERVER_PORT
-              value: {{ .Values.backend.redisPort | quote }}
-            {{- end }}
-            {{- if .Values.backend.redisDbResult }}
-            - name: RSTUF_REDIS_SERVER_DB_RESULT
-              value: {{ .Values.backend.redisDbResult | quote }}
-            {{- end }}
-            {{- if .Values.backend.redisDbSettings }}
-            - name: RSTUF_REDIS_SERVER_DB_REPO_SETTINGS
-              value: {{ .Values.backend.redisDbSettings | quote }}
             {{- end }}
             {{- if .Values.backend.lockTimeOut }}
             - name: RSTUF_LOCK_TIMEOUT
@@ -136,7 +165,7 @@ spec:
         {{- range .Values.onlineKeyFile }}
         - name: {{ .keyid | printf "%.7s" }}-keyfile-volume
           secret:
-            secretName: {{ .keyid }}-keyfile-secret
+            secretName: {{ .secretName | default (printf "%s-keyfile-secret" .keyid) }}
         {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/rstuf-worker/templates/secrets.yaml
+++ b/charts/rstuf-worker/templates/secrets.yaml
@@ -14,6 +14,7 @@ data:
 {{- if and (.Values.onlineKeyDir) (.Values.onlineKeyFile) }}
 ---
 {{- range .Values.onlineKeyFile }}
+{{- if not .secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -22,5 +23,6 @@ type: Opaque
 data:
   {{ .keyid }}: {{ .pem | quote }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/rstuf-worker/values.yaml
+++ b/charts/rstuf-worker/values.yaml
@@ -4,6 +4,12 @@
 
 replicaCount: 1
 
+strategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 0
+
 image:
   repository: ghcr.io/repository-service-tuf/repository-service-tuf-worker
   pullPolicy: IfNotPresent
@@ -39,7 +45,18 @@ storage:
   s3Bucket: "tuf-metadata"
 aws:
   accessKey: "s3-keyid"
+  # accessKeyFrom:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: rstuf-s3-rw
+  #       key: ACCESS_KEY
   secretKey: "s3-access-key"
+  # secretKeyFrom:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: rstuf-s3-rw
+  #       key: SECRET_KEY
+  # Note: direct value takes priority over *From
   region: ""
   endpoint: ""
   s3_object_acl: ""  # default is public-read
@@ -50,29 +67,51 @@ gcp:
 backend:
   brokerServer: "redis://redis"
   redisServer: "redis://redis"
-  dbServer: "postgresql://postgres:password@postgres:5432"
-  # lockTimeOut default 60 seconds
-  lockTimeOut: ""
-  # redisPort default is 5672
+  # redisPort default is 6379
   redisPort: ""
-  # redisDbResultdefault is 0
+  # redisDbResult default is 0
   redisDbResult: ""
   # redisDbSettings default is 1
   redisDbSettings: ""
+  # To use dbServerFrom, set dbServer: ""
+  dbServer: "postgresql://postgres:password@postgres:5432"
+  # dbServerFrom:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: rstuf-database
+  #       key: RSTUF_DB_SERVER
+  # dbUser and dbPassword are required when dbServer is not a full URL with credentials
+  dbUser: ""
+  # dbUserFrom:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: rstuf-database
+  #       key: RSTUF_DB_USER
+  dbPassword: ""
+  # dbPasswordFrom:
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: rstuf-database
+  #       key: RSTUF_DB_PASSWORD
+  # Note: direct value takes priority over *From
+  # lockTimeOut default 60 seconds
+  lockTimeOut: ""
 
-# using online key as file in seccrets
-# onlineKeyDir: "/run/secrets"
-# onlineKeyFile:
-#   - keyid: 0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043
-#     # pem must be base64 encoded
-#     pem: |
-#       LS0tLS1CRUdJTi(...)
+onlineKeyDir: "/run/secrets"
+onlineKeyFile: []
+  # Variant 1: create secret from pem
+  # - keyid: 0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043
+  #   pem: LS0tLS1CRUdJTi(...)
+  # Variant 2: use existing secret
+  # - keyid: 0d9d3d4bad91c455bc03921daa95774576b86625ac45570d0cac025b08e65043
+  #   secretName: my-secret
+  #   secretKey: key-in-secret  # defaults to keyid
 
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Automatically mount a ServiceAccount's API credentials?
-  automount: true
+  automount: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.


### PR DESCRIPTION
- Add deployment strategy configuration support
- Add valueFrom support for AWS credentials (accessKeyFrom, secretKeyFrom)
- Add valueFrom support for DB credentials (dbServerFrom, dbUserFrom, dbPasswordFrom)
- Add separate dbUser and dbPassword fields for database
- Add support for existing Kubernetes secrets in onlineKeyFile (secretName, secretKey)
- Set default onlineKeyDir to "/run/secrets"
- Fix redisPort default comment (5672 -> 6379)
- Reorganize Redis env vars for consistency

BREAKING CHANGE: serviceAccount.automount defaults to false following the principle of least privilege