### PR TITLE
feat(rstuf-worker): add configurable database keepalive variables

### DIFF
--- a/charts/rstuf-worker/Chart.yaml
+++ b/charts/rstuf-worker/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.4
+version: 0.4.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rstuf-worker/templates/deployment.yaml
+++ b/charts/rstuf-worker/templates/deployment.yaml
@@ -104,6 +104,16 @@ spec:
             - name: RSTUF_DB_PASSWORD
               {{- toYaml .Values.backend.dbPasswordFrom | nindent 14 }}
             {{- end }}
+            {{- if .Values.backend.dbKeepAlive }}
+            - name: RSTUF_DB_KEEPALIVE
+              value: "true"
+            - name: RSTUF_DB_KEEPALIVE_IDLE
+              value: {{ .Values.backend.dbKeepAliveIdle | quote }}
+            - name: RSTUF_DB_KEEPALIVE_INTERVAL
+              value: {{ .Values.backend.dbKeepAliveInterval | quote }}
+            - name: RSTUF_DB_KEEPALIVE_COUNT
+              value: {{ .Values.backend.dbKeepAliveCount | quote }}
+            {{- end }}
             - name: RSTUF_STORAGE_BACKEND
               value: {{ required "storage.type must be 'AWSS3' or 'LocalStorage'." .Values.storage.type | quote }}
             {{- if eq .Values.storage.type "LocalStorage" }}

--- a/charts/rstuf-worker/values.yaml
+++ b/charts/rstuf-worker/values.yaml
@@ -94,6 +94,11 @@ backend:
   #       name: rstuf-database
   #       key: RSTUF_DB_PASSWORD
   # Note: direct value takes priority over *From
+  # Database keepalive settings
+  dbKeepAlive: false
+  dbKeepAliveIdle: 30
+  dbKeepAliveInterval: 5
+  dbKeepAliveCount: 3
   # lockTimeOut default 60 seconds
   lockTimeOut: ""
 


### PR DESCRIPTION
Added environment variables for PostgreSQL keepalive:
- RSTUF_DB_KEEPALIVE (disabled by default)
- RSTUF_DB_KEEPALIVE_IDLE (default 30)
- RSTUF_DB_KEEPALIVE_INTERVAL (default 5)
- RSTUF_DB_KEEPALIVE_COUNT (default 3)

https://github.com/repository-service-tuf/repository-service-tuf-worker/pull/928
