### PR TITLE
feat: clarify chart and container versioning

### DIFF
--- a/charts/rstuf-api/Chart.yaml
+++ b/charts/rstuf-api/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.1"
+appVersion: "v1.0.1"

--- a/charts/rstuf-api/values.yaml
+++ b/charts/rstuf-api/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/repository-service-tuf/repository-service-tuf-api
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v1.0.0"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/rstuf-worker/Chart.yaml
+++ b/charts/rstuf-worker/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.2"
+appVersion: "v1.0.2"

--- a/charts/rstuf-worker/values.yaml
+++ b/charts/rstuf-worker/values.yaml
@@ -13,7 +13,7 @@ strategy: {}
 image:
   repository: ghcr.io/repository-service-tuf/repository-service-tuf-worker
   pullPolicy: IfNotPresent
-  tag: "v1.0.0"
+  tag: ""
 
 livenessProbe:
   exec:


### PR DESCRIPTION
- Remove ambiguity between chart version and container image version
- Container image version is now determined solely by appVersion
- Image tag can still be explicitly set via values.yaml if needed
- Bump chart versions following semver for dependency and template changes