### PR TITLE
feat: add extraEnv support and migrate s3Bucket to aws config

### DIFF
--- a/charts/rstuf-api/Chart.yaml
+++ b/charts/rstuf-api/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rstuf-api/templates/deployment.yaml
+++ b/charts/rstuf-api/templates/deployment.yaml
@@ -83,6 +83,9 @@ spec:
             - name: SECRETS_RSTUF_SSL_KEY
               value: {{ .Values.service.ssl_key | quote }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/charts/rstuf-api/values.yaml
+++ b/charts/rstuf-api/values.yaml
@@ -61,6 +61,8 @@ backend:
   # See https://repository-service-tuf.readthedocs.io/en/stable/guide/repository-service-tuf-api/Docker_README.html#optional-rstuf-disabled-endpoints
   disabledEndpoints: ""
 
+extraEnv: []
+
 ingress:
   enabled: false
   className: ""

--- a/charts/rstuf-worker/Chart.yaml
+++ b/charts/rstuf-worker/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/rstuf-worker/templates/NOTES.txt
+++ b/charts/rstuf-worker/templates/NOTES.txt
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.storage.type "AWSS3") (not .Values.aws.s3Bucket) }}
+WARNING - DEPRECATION:
+  .Values.storage.s3Bucket is deprecated and will be removed in a future release.
+  Please migrate to .Values.aws.s3Bucket instead.
+
+  Migration: in your values.yaml, move:
+    storage:
+      s3Bucket: "your-bucket"       ← remove this line
+    aws:
+      s3Bucket: "your-bucket"       ← add this line
+{{- end }}

--- a/charts/rstuf-worker/templates/deployment-s3-gateway.yaml
+++ b/charts/rstuf-worker/templates/deployment-s3-gateway.yaml
@@ -62,7 +62,7 @@ spec:
             - name: S3_REGION
               value: {{ .Values.aws.region | quote }}
             - name: S3_BUCKET_NAME
-              value: {{  .Values.storage.s3Bucket | quote }}
+              value: {{ (.Values.aws.s3Bucket | default .Values.storage.s3Bucket) | quote }}
             {{- if .Values.s3Gateway.accessKey }}
             - name: AWS_ACCESS_KEY_ID
               value: {{ .Values.s3Gateway.accessKey | quote }}
@@ -76,6 +76,9 @@ spec:
             {{- else if .Values.s3Gateway.secretKeyFrom }}
             - name: AWS_SECRET_ACCESS_KEY
               {{- toYaml .Values.s3Gateway.secretKeyFrom | nindent 14 }}
+            {{- end }}
+            {{- with .Values.s3Gateway.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http

--- a/charts/rstuf-worker/templates/deployment.yaml
+++ b/charts/rstuf-worker/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- if .Values.initContainers }}
       initContainers:
         {{- toYaml .Values.initContainers | nindent 8 }}
-      {{- end }}     
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -121,13 +121,17 @@ spec:
             - name: RSTUF_LOCAL_STORAGE_BACKEND_PATH
               value: {{ required "storage.backendPath is required when storage.type is 'LocalStorage'." .Values.storage.storagePath | quote }}
             {{- end }}
-            {{- if and .Values.onlineKeyDir .Values.onlineKeyFile }}
-            - name: RSTUF_ONLINE_KEY_DIR
-              value: {{ .Values.onlineKeyDir | quote }}
+            {{- if .Values.aws.endpoint }}
+            - name: RSTUF_AWS_ENDPOINT_URL
+              value: {{ .Values.aws.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.aws.region }}
+            - name: RSTUF_AWS_DEFAULT_REGION
+              value: {{ .Values.aws.region | quote }}
             {{- end }}
             {{- if eq .Values.storage.type "AWSS3" }}
             - name: RSTUF_AWS_STORAGE_BUCKET
-              value: {{ required "storage.s3Bucket is required when storage.type is 'AWSS3'." .Values.storage.s3Bucket | quote }}
+              value: {{ required "aws.s3Bucket is required when storage.type is 'AWSS3'." (.Values.aws.s3Bucket | default .Values.storage.s3Bucket) | quote }}
             {{- end }}
             {{- if .Values.aws.accessKey }}
             - name: RSTUF_AWS_ACCESS_KEY_ID
@@ -143,25 +147,24 @@ spec:
             - name: RSTUF_AWS_SECRET_ACCESS_KEY
               {{- toYaml .Values.aws.secretKeyFrom | nindent 14 }}
             {{- end }}
-            {{- if .Values.aws.region }}
-            - name: RSTUF_AWS_DEFAULT_REGION
-              value: {{ .Values.aws.region | quote }}
-            {{- end }}
-            {{- if .Values.aws.endpoint }}
-            - name: RSTUF_AWS_ENDPOINT_URL
-              value: {{ .Values.aws.endpoint | quote }}
-            {{- end }}
             {{- if .Values.aws.s3_object_acl }}
             - name: RSTUF_AWS_S3_OBJECT_ACL
               value: {{ .Values.aws.s3_object_acl | quote }}
+            {{- end }}
+            {{- if and .Values.onlineKeyDir .Values.onlineKeyFile }}
+            - name: RSTUF_ONLINE_KEY_DIR
+              value: {{ .Values.onlineKeyDir | quote }}
+            {{- end }}
+            {{- if .Values.gcp.applicationCredentials }}
+            - name: RSTUF_GOOGLE_APPLICATION_CREDENTIALS
+              value: /run/secrets/gcp-credentials/ac.json
             {{- end }}
             {{- if .Values.backend.lockTimeOut }}
             - name: RSTUF_LOCK_TIMEOUT
               value: {{ .Values.backend.lockTimeOut | quote }}
             {{- end }}
-            {{- if .Values.gcp.applicationCredentials }}
-            - name: RSTUF_GOOGLE_APPLICATION_CREDENTIALS
-              value: /run/secrets/gcp-credentials/ac.json
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
         {{- with .Values.volumes }}

--- a/charts/rstuf-worker/values.yaml
+++ b/charts/rstuf-worker/values.yaml
@@ -41,9 +41,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 storage:
-  type: "AWSS3" # AWSS3 or localStorage
-  storagePath: "" # required only when using `storageBackend` as "localStorage"
-  s3Bucket: "tuf-metadata" # Deprecated, kept for backward compatibility. Will be removed in a future release. Use `aws.s3Bucket` instead.
+  type: "AWSS3"             # AWSS3 or localStorage
+  storagePath: ""           # required only when using `storageBackend` as "localStorage"
+  s3Bucket: "tuf-metadata"  # Deprecated, kept for backward compatibility. Will be removed in a future release. Use `aws.s3Bucket` instead.
 aws:
   endpoint: ""
   region: ""
@@ -61,7 +61,7 @@ aws:
   #       name: rstuf-s3-rw
   #       key: SECRET_KEY
   # Note: direct value takes priority over *From
-  s3_object_acl: "" # default is public-read
+  s3_object_acl: ""  # default is public-read
 gcp:
   # Use applicationCredentials as base64
   applicationCredentials: ""

--- a/charts/rstuf-worker/values.yaml
+++ b/charts/rstuf-worker/values.yaml
@@ -18,11 +18,12 @@ image:
 livenessProbe:
   exec:
     # bash is needed to replace the environment variable
-    command: [
-      "bash",
-      "-c",
-      "RSTUF_WORKER_ID=$HOSTNAME celery -A app inspect ping rstuf@$HOSTNAME,rstuf_jobs@$HOSTNAME"
-    ]
+    command:
+      [
+        "bash",
+        "-c",
+        "RSTUF_WORKER_ID=$HOSTNAME celery -A app inspect ping rstuf@$HOSTNAME,rstuf_jobs@$HOSTNAME",
+      ]
   initialDelaySeconds: 30
   periodSeconds: 60
   timeoutSeconds: 10
@@ -32,7 +33,7 @@ readinessProbe:
       [
         "/usr/local/bin/python",
         "-c",
-        "\"import os;os.environ['RSTUF_WORKER_ID']=os.environ['HOSTNAME'];from app import app;exit(0 if os.environ['HOSTNAME'] in ','.join(app.control.inspect(app=app).stats().keys()) else 1)\""
+        '"import os;os.environ[''RSTUF_WORKER_ID'']=os.environ[''HOSTNAME''];from app import app;exit(0 if os.environ[''HOSTNAME''] in '',''.join(app.control.inspect(app=app).stats().keys()) else 1)"',
       ]
 
 imagePullSecrets: []
@@ -40,10 +41,13 @@ nameOverride: ""
 fullnameOverride: ""
 
 storage:
-  type: "AWSS3"    # AWSS3 or localStorage
-  storagePath: ""  # required only when using `storageBackend` as "localStorage"
-  s3Bucket: "tuf-metadata"
+  type: "AWSS3" # AWSS3 or localStorage
+  storagePath: "" # required only when using `storageBackend` as "localStorage"
+  s3Bucket: "tuf-metadata" # Deprecated, kept for backward compatibility. Will be removed in a future release. Use `aws.s3Bucket` instead.
 aws:
+  endpoint: ""
+  region: ""
+  s3Bucket: ""
   accessKey: "s3-keyid"
   # accessKeyFrom:
   #   valueFrom:
@@ -57,9 +61,7 @@ aws:
   #       name: rstuf-s3-rw
   #       key: SECRET_KEY
   # Note: direct value takes priority over *From
-  region: ""
-  endpoint: ""
-  s3_object_acl: ""  # default is public-read
+  s3_object_acl: "" # default is public-read
 gcp:
   # Use applicationCredentials as base64
   applicationCredentials: ""
@@ -101,6 +103,11 @@ backend:
   dbKeepAliveCount: 3
   # lockTimeOut default 60 seconds
   lockTimeOut: ""
+
+# Additional environment variables
+extraEnv: []
+  # - name: AWS_REQUEST_CHECKSUM_CALCULATION
+  #   value: "when_required"
 
 onlineKeyDir: "/run/secrets"
 onlineKeyFile: []
@@ -216,6 +223,7 @@ s3Gateway:
   #       name: rstuf-s3-ro
   #       key: SECRET_KEY
   # Note: direct value takes priority over *From
+  extraEnv: []
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
- Move s3Bucket configuration from storage.s3Bucket to aws.s3Bucket with backward compatibility (storage.s3Bucket kept as deprecated)
- Add extraEnv support for rstuf-worker, rstuf-worker s3-gateway, and rstuf-api to allow custom environment variables
- Add NOTES.txt deprecation warning displayed in Helm CLI when storage.s3Bucket is used without aws.s3Bucket
- Took the liberty to regroup environment variables in deployment templates for more logical ordering (AWS settings grouped together)
- Minor formatting fixes (trailing whitespace, YAML style)